### PR TITLE
Download full-size images by stripping the size suffix from image urls

### DIFF
--- a/app/downloadEngine.js
+++ b/app/downloadEngine.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const cheerio = require('cheerio');
 const async = require('async');
 const path = require('path');
-// last page http://stanikus.soup.io/since/258895020
+// last page       http://stanikus.soup.io/since/258895020
 // after last page http://stanikus.soup.io/since/258894239?
 
 // config
@@ -71,12 +71,14 @@ async function downloadFile(task) {
 }
 
 function proceedElement(elem) {
-  // console.log(elem);
   const url = elem.attribs.src;
-  console.log(url);
-  allMedia.push(url);
+  // strip size suffix from image src to download the full-size image
+  const re = /_\d{3}\./;
+  const fUrl = url.replace(re, '.');
+  console.log(fUrl);
+  allMedia.push(fUrl);
   // push a new line into the queue to be processed
-  q.push({ url });
+  q.push({ url: fUrl });
 }
 
 async function fetchUntilEnd(url) {


### PR DESCRIPTION
The img src on soup.io usually points to a smaller image, with _500 suffix before the extension, returning 500px-wide image. Sometimes it's a link to url with _960 suffix which is already better, but what soup also stores and makes available is the unprocessed, full image file available by just stripping the suffix.

This pull request adds replacing these suffixes with simple regexp to fetch the largest size image possible. Manually tested to work.